### PR TITLE
Add the Expose instruction in Dockerfile.standalone 

### DIFF
--- a/docker/latest/Dockerfile.standalone
+++ b/docker/latest/Dockerfile.standalone
@@ -15,4 +15,5 @@ RUN go build -ldflags "-w -s" -o md main.go && \
 FROM "alpine:$VER_ALPINE"
 LABEL MAINTAINER soulteary<soulteary@gmail.com>
 COPY --from=GoBuilder /app/md.minify /bin/md
+EXPOSE 80
 CMD ["md"]


### PR DESCRIPTION
If Docker is not told the exposed port via EXPOSE, then Traefik will not be able to get that information automatically